### PR TITLE
clojuredocs.org를 조회하는 터미널 클라이언트를 만들어라

### DIFF
--- a/bin/clojuredocs
+++ b/bin/clojuredocs
@@ -5,6 +5,19 @@
 # bat - https://github.com/sharkdp/bat
 # fzf - https://github.com/junegunn/fzf
 
+# 사용방법
+# EXAMPLE:
+#   clojuredocs.org 에서 merge 로 검색한 결과를 봅니다.
+#   결과를 보다가 엔터키를 입력하면 clojuredocs.org의 해당 페이지를 웹 브라우저에서 열어줍니다.
+#   (다운로드한 내용은 /tmp/clojuredocs 에 저장됩니다.)
+#       $ clojuredocs merge
+#
+#   기본 옵션과 같습니다. 단 로컬 캐시를 모두 삭제합니다.
+#   $ clojuredocs merge -f
+#
+#   clojuredocs.org 에서 merge 로 검색한 결과를 출력합니다. 결과를 적당히 파싱해 쓰면 됩니다.
+#   $ clojuredocs merge -r
+
 main() {
     _keyword="$1"
     _option="$2"

--- a/bin/clojuredocs
+++ b/bin/clojuredocs
@@ -37,7 +37,10 @@ show_examples() {
     _keyword="$1"
 
     search_list "$_keyword" \
-        | fzf --preview 'printf {3} | shasum | tr "-" " " | xargs printf "/tmp/clojuredocs/examples/%s" | xargs bat -l clojure -p --theme Dracula --color=always' --preview-window=wrap --multi \
+        | fzf  --preview-window=wrap --multi \
+            --preview "printf {3} | shasum | tr '-' ' ' \
+                | xargs printf '/tmp/clojuredocs/examples/%s' \
+                | xargs bat -l clojure -p --theme Dracula --color=always" \
         | awk '{print $3}' \
         | xargs open
     }

--- a/bin/clojuredocs
+++ b/bin/clojuredocs
@@ -56,9 +56,8 @@ save_each_example() {
         _file_name=/tmp/clojuredocs/examples/$_url_id
         _index=$(expr $_index + 1)
 
-        if [ ! -f $_file_name ]; then
+        if [[ ! -f $_file_name && ! -z $url ]]; then
             # 예제를 저장한 캐시 파일이 없다면, 예제를 다운로드 받아서 /tmp/clojuredocs/examples 에 저장한다.
-
             printf "캐시를 갱신합니다 [%d / %d] %s\n" $_index $_length $url
 
             bb -i "
@@ -78,6 +77,8 @@ save_each_example() {
                 (doseq [example examples] (println example))
                 " \
                 > $_file_name
+        else
+            printf "캐시를 갱신하지 않습니다 [%d / %d] %s\n" $_index $_length $url
         fi
     done
 }
@@ -96,13 +97,12 @@ search_list() {
         # 파일이 최근에 업데이트 되었고,
         if ! [ $_file_line_count = "0" ]; then
             # 파일이 비어있지 않으면
-            # echo "최근에 저장해둔 $_file_name 내용을 출력합니다."
             cat $_file_name
             return 0
         fi
     fi
 
-    curl_from_clojuredocs "$_keyword" > $_file_name
+    curl_from_clojuredocs "$_keyword" | grep -v '^<' | column -t > $_file_name
 
     # 재귀하고 싶지만 참는다...
     cat $_file_name
@@ -116,8 +116,7 @@ curl_from_clojuredocs() {
         | egrep -o '"search-results".*"search-controls"' \
         | egrep -o "<h2>.*?</h3>" \
         | sed -E 's,^.*href="/([^"]+)/([^/]+)".*$,\1 \2 https://clojuredocs.org/\1/\2,' \
-        | sed 's/&nbsp;/ /g; s/&amp;/\&/g; s/&lt;/\</g; s/&gt;/\>/g; s/&quot;/\"/g; s/#&#39;/\'"'"'/g; s/&ldquo;/\"/g; s/&rdquo;/\"/g;' \
-        | column -t
+        | sed 's/&nbsp;/ /g; s/&amp;/\&/g; s/&lt;/\</g; s/&gt;/\>/g; s/&quot;/\"/g; s/#&#39;/\'"'"'/g; s/&ldquo;/\"/g; s/&rdquo;/\"/g;'
 }
 
 main $@

--- a/bin/clojuredocs
+++ b/bin/clojuredocs
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# 이 프로그램은 다음에 의존합니다.
+# bb - https://github.com/babashka/babashka
+# bat - https://github.com/sharkdp/bat
+# fzf - https://github.com/junegunn/fzf
+
+main() {
+    _keyword="$1"
+    _option="$2"
+
+    mkdir -p /tmp/clojuredocs/search /tmp/clojuredocs/examples
+
+    # -f 는 강제 업데이트 옵션
+    if [[ "$_option" == "-f" ]]; then
+        find /tmp/clojuredocs/ 2> /dev/null | xargs \rm 2> /dev/null
+    else
+        # 30일이 지난 캐시 파일을 삭제한다.
+        find /tmp/clojuredocs/ -mtime +30 2> /dev/null \
+            | xargs \rm 2> /dev/null
+    fi
+
+    case "$_option" in
+        "-r"|"--raw")
+            # -r 옵션은 순수한 리스트만 확인한다.
+            search_list "$_keyword"
+            ;;
+        *)
+            # 각 예제의 캐시를 갱신한다.
+            save_each_example "$_keyword"
+            # 리스트를 통해 각 예제의 미리보기를 fzf를 통해 보여준다.
+            show_examples "$_keyword"
+    esac
+}
+
+show_examples() {
+    _keyword="$1"
+
+    search_list "$_keyword" \
+        | fzf --preview 'printf {3} | shasum | tr "-" " " | xargs printf "/tmp/clojuredocs/examples/%s" | xargs bat -l clojure -p --theme Dracula --color=always' --preview-window=wrap --multi \
+        | awk '{print $3}' \
+        | xargs open
+    }
+
+save_each_example() {
+    _keyword="$1"
+    readarray -t url_list < <(search_list "$_keyword" | awk '{print $3}')
+
+    _length=${#url_list[@]}
+    printf "검색 결과가 %d 개 있습니다.\n" $_length
+
+    # 키워드와 관계 있는 예제 페이지들의 url 을 순회하며 예제를 저장한다.
+    _index=0
+    for url in "${url_list[@]}"; do
+        _url_id=$(printf $url | shasum | tr '-' ' ')
+        _file_name=/tmp/clojuredocs/examples/$_url_id
+        _index=$(expr $_index + 1)
+
+        if [ ! -f $_file_name ]; then
+            # 예제를 저장한 캐시 파일이 없다면, 예제를 다운로드 받아서 /tmp/clojuredocs/examples 에 저장한다.
+
+            printf "캐시를 갱신합니다 [%d / %d] %s\n" $_index $_length $url
+
+            bb -i "
+                (require '[clojure.edn :as edn] '[babashka.curl :as curl] '[clojure.string :as str])
+                (def raw-data (->> (curl/get \"$url\")
+                                  :body
+                                  (re-find #\"(?<=window\.PAGE_DATA=).*(?=;\s//\]\]></script>)\")
+                                  edn/read-string
+                                  edn/read-string))
+                (def examples
+                  (->> raw-data
+                      :examples
+                      (map :body)
+                      (map-indexed (fn [index item]
+                          (str \"\n;; << Example number: \" index \" >>\\n\" item)))))
+                ;(println raw-data)
+                (doseq [example examples] (println example))
+                " \
+                > $_file_name
+        fi
+    done
+}
+
+# 검색 결과를 가져와 리턴합니다.
+# 캐시 파일이 있다면 캐시 파일 내용을 보여줍니다.
+search_list() {
+    _keyword="$1"
+    # _file_name="/tmp/clojuredocs/search/$(base64 <<< "$_keyword")"
+    _file_name="/tmp/clojuredocs/search/$(shasum <<< "$_keyword" | tr '-' ' ')"
+
+    _file_recently_updated=$(find $_file_name -mtime -7 2> /dev/null | wc -l)
+    _file_line_count=$(wc -l $_file_name 2> /dev/null | awk '{print $1}')
+
+    if [ $_file_recently_updated = "1" ]; then
+        # 파일이 최근에 업데이트 되었고,
+        if ! [ $_file_line_count = "0" ]; then
+            # 파일이 비어있지 않으면
+            # echo "최근에 저장해둔 $_file_name 내용을 출력합니다."
+            cat $_file_name
+            return 0
+        fi
+    fi
+
+    curl_from_clojuredocs "$_keyword" > $_file_name
+
+    # 재귀하고 싶지만 참는다...
+    cat $_file_name
+    return 0
+}
+
+# clojuredocs.org 검색 결과를 가져와 리턴합니다.
+curl_from_clojuredocs() {
+    curl -s "https://clojuredocs.org/search?q=$1" \
+        | tr '\n' ' ' \
+        | egrep -o '"search-results".*"search-controls"' \
+        | egrep -o "<h2>.*?</h3>" \
+        | sed -E 's,^.*href="/([^"]+)/([^/]+)".*$,\1 \2 https://clojuredocs.org/\1/\2,' \
+        | column -t
+}
+
+main $@
+

--- a/bin/clojuredocs
+++ b/bin/clojuredocs
@@ -116,6 +116,7 @@ curl_from_clojuredocs() {
         | egrep -o '"search-results".*"search-controls"' \
         | egrep -o "<h2>.*?</h3>" \
         | sed -E 's,^.*href="/([^"]+)/([^/]+)".*$,\1 \2 https://clojuredocs.org/\1/\2,' \
+        | sed 's/&nbsp;/ /g; s/&amp;/\&/g; s/&lt;/\</g; s/&gt;/\>/g; s/&quot;/\"/g; s/#&#39;/\'"'"'/g; s/&ldquo;/\"/g; s/&rdquo;/\"/g;' \
         | column -t
 }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/1855714/153747163-937b4768-80b3-404d-9e24-4ae3bb9e3049.mp4

## 사용 방법

```sh
# clojuredocs.org 에서 defn 의 사용 예제를 검색합니다. (자동으로 로컬에 캐시를 저장합니다)
clojuredocs defn
```

```sh
# 캐시를 삭제하고 검색합니다.
clojuredocs defn -f
```

- 화면 오른쪽의 예제 미리보기는 마우스로 스크롤이 됩니다.
- 검색 결과를 선택하고 엔터를 누르면 웹 브라우저에서 해당 예제를 열어줍니다. (싫으면 `^c`)를 누르면 터미널로 돌아갑니다.
- `tab` 키를 누르면 여러 예제를 선택할 수 있습니다. 여러 예제를 선택하고 엔터를 누르면 웹 브라우저에 해당 예제들의 탭을 열어줍니다.

## 의존하는 다른 프로그램

- fzf
- babashka
- bat